### PR TITLE
Create .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# autoformat commits
+d550781ba6f71283e8af88fe3b84cda9b24b8ced


### PR DESCRIPTION
Allows ignoring autoformat commits when viewing blame